### PR TITLE
Use `documentserver-ee` for all testing purposes

### DIFF
--- a/docker-update.sh
+++ b/docker-update.sh
@@ -21,5 +21,5 @@ docker run -i -t -d -p 80:80 -p 443:443 --name DocumentServer \
  -e JWT_ENABLED=true \
  -e JWT_SECRET=doc-linux \
  -e JWT_HEADER=AuthorizationJwt \
- onlyoffice/4testing-documentserver-ie:${VERSION}
+ onlyoffice/4testing-documentserver-ee:${VERSION}
 bash after-run.sh


### PR DESCRIPTION
According to 
https://t.me/c/1307310792/16357

`-ie` is now deprecated and probably will not released any more