### PR TITLE
Increase timeout to wait for DS to start

### DIFF
--- a/after-run.sh
+++ b/after-run.sh
@@ -1,6 +1,6 @@
 PACKAGE_TYPE='onlyoffice-documentserver-ee'
-echo 'Sleep for 30 seconds to wait until documentserver reinitialize himself'
-sleep 30
+echo 'Sleep for 90 seconds to wait until documentserver reinitialize himself'
+sleep 90
 JSON_EXE=/var/www/onlyoffice/documentserver/npm/json
 
 docker exec -it DocumentServer $JSON_EXE -f /etc/onlyoffice/documentserver/default.json -I -e 'this.services.CoAuthoring.expire.sessionidle="1h"'


### PR DESCRIPTION
Changed in https://github.com/onlyoffice/Docker-DocumentServer/compare/v6.1.0.72...v6.1.0.73#diff-dad7b84674fccc140b0fb2f17af742872a2f5cda5ddd36af501f39b404baf0cbR39
After upgrade base image to Ubuntu 20.04